### PR TITLE
Update Base.java

### DIFF
--- a/src/main/java/org/anystub/Base.java
+++ b/src/main/java/org/anystub/Base.java
@@ -339,10 +339,12 @@ public class Base {
         // keep values
         Document retrievedDocument = new Document(keys);
 
+        Iterable<String> responseData = null;
         if (res == null) {
             retrievedDocument.setNull();
         }else{
-            retrievedDocument.setValues(encoder.encode(res));
+            responseData = encoder.encode(res);
+            retrievedDocument.setValues(responseData);
         }
         put(retrievedDocument);
         requestHistory.add(retrievedDocument);
@@ -351,7 +353,11 @@ public class Base {
         } catch (IOException ex) {
             log.warning("keep data failed: " + ex.getMessage());
         }
-        return res;
+        if (responseData != null) {
+            return decoder.decode(responseData);
+        } else {
+            return null;
+        }
     }
 
 


### PR DESCRIPTION
Decode responseData with decoder instead of returning it directly to keep internal state of response in case it has one.
Because response serialization might change response internal before.