### PR TITLE
use unicode for cassettes independently from OS, locale

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.200</version>
+            <version>2.0.202</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.anystub</groupId>
     <artifactId>anystub</artifactId>
-    <version>0.7.6-SNAPSHOT</version>
+    <version>0.7.6</version>
     <packaging>jar</packaging>
 
     <name>anystub</name>
@@ -30,7 +30,7 @@
         <url>anystub-repo</url>
         <connection>scm:git:git@github.com:anystub/anystub.git</connection>
         <developerConnection>scm:git:git@github.com:anystub/anystub.git</developerConnection>
-      <tag>anystub-0.4.1</tag>
+      <tag>anystub-0.7.6</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.anystub</groupId>
     <artifactId>anystub</artifactId>
-    <version>0.7.6</version>
+    <version>0.7.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>anystub</name>
@@ -30,7 +30,7 @@
         <url>anystub-repo</url>
         <connection>scm:git:git@github.com:anystub/anystub.git</connection>
         <developerConnection>scm:git:git@github.com:anystub/anystub.git</developerConnection>
-      <tag>anystub-0.7.6</tag>
+      <tag>anystub-0.4.1</tag>
     </scm>
 
     <properties>

--- a/src/main/java/org/anystub/Base.java
+++ b/src/main/java/org/anystub/Base.java
@@ -560,7 +560,8 @@ public class Base {
      */
     private void load() throws IOException {
         File file = new File(filePath);
-        try (InputStream input = new FileInputStream(file)) {
+        try (InputStream inputStream = new FileInputStream(file);
+             InputStreamReader input = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
             Yaml yaml = new Yaml(new SafeConstructor());
             Object load = yaml.load(input);
 

--- a/src/main/java/org/anystub/EncoderJson.java
+++ b/src/main/java/org/anystub/EncoderJson.java
@@ -8,8 +8,7 @@ public class EncoderJson<R extends Object>  implements EncoderSimple<R>{
         if (r==null) {
             return "";
         }
-        if (r.getClass().isPrimitive() ||
-            r.getClass().equals(String.class)) {
+        if (r.getClass().equals(String.class)) {
             return String.valueOf(r);
         }
 

--- a/src/main/java/org/anystub/jdbc/ResultSetUtil.java
+++ b/src/main/java/org/anystub/jdbc/ResultSetUtil.java
@@ -167,6 +167,12 @@ public class ResultSetUtil {
             if (resultSet.wasNull()) {
                 return null;
             }
+
+            if (columnType == CHAR ||
+                    columnType == VARCHAR ||
+                    columnType == LONGVARCHAR) {
+                return value.toString();
+            }
             return ObjectMapperFactory.get().writeValueAsString(value);
         } catch (SQLException | JsonProcessingException e) {
             LOGGER.severe(() -> String.format("Failed encode value on %d of type %d", column, columnType));

--- a/src/main/java/org/anystub/jdbc/ResultSetUtil.java
+++ b/src/main/java/org/anystub/jdbc/ResultSetUtil.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.anystub.ObjectMapperFactory;
 import org.h2.tools.SimpleResultSet;
 
+import java.sql.Blob;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -173,6 +174,55 @@ public class ResultSetUtil {
                     columnType == LONGVARCHAR) {
                 return value.toString();
             }
+
+            switch (columnType) {
+//            case  BIT = -7;
+//                case TINYINT:
+//                case SMALLINT:
+//                case INTEGER:
+//                case BIGINT:
+//                case FLOAT:
+//                case NUMERIC:
+//                case DECIMAL:
+//                case REAL:
+//                case DOUBLE:
+                case CHAR:
+                case VARCHAR:
+                case LONGVARCHAR:
+                case NCHAR:
+                    return resultSet.getString(column);
+//                case DATE:
+//                case TIME:
+//                case TIMESTAMP:
+//            case  BINARY = -2;
+//            case  VARBINARY = -3;
+//            case  LONGVARBINARY = -4;
+//            case  NULL = 0;
+//            case  OTHER = 1111;
+//            case  JAVA_OBJECT = 2000;
+//            case  DISTINCT = 2001;
+//            case  STRUCT = 2002;
+//            case  ARRAY = 2003;
+                case BLOB:
+                    return SqlTypeEncoder.encodeBlob(resultSet.getBlob(column));
+                case CLOB:
+                    return SqlTypeEncoder.encodeClob(resultSet.getClob(column));
+//            case  REF = 2006;
+//            case  DATALINK = 70;
+//                case BOOLEAN:
+                case ROWID:
+                    return SqlTypeEncoder.encodeRowid(resultSet.getRowId(column));
+//            case  NVARCHAR = -9;
+//            case  LONGNVARCHAR = -16;
+//            case  NCLOB = 2011;
+                case SQLXML:
+                    return SqlTypeEncoder.encodeSQLXML(resultSet.getSQLXML(column));
+//            case  REF_CURSOR = 2012;
+//            case  TIME_WITH_TIMEZONE = 2013;
+//            case  TIMESTAMP_WITH_TIMEZONE = 2014;
+                default:
+            }
+
             return ObjectMapperFactory.get().writeValueAsString(value);
         } catch (SQLException | JsonProcessingException e) {
             LOGGER.severe(() -> String.format("Failed encode value on %d of type %d", column, columnType));
@@ -230,6 +280,7 @@ public class ResultSetUtil {
 //            case  STRUCT = 2002;
 //            case  ARRAY = 2003;
             case BLOB:
+//                return decodeValue(next, Blob.class, null);
                 return SqlTypeEncoder.decodeBlob(next);
             case CLOB:
                 return SqlTypeEncoder.decodeClob(next);

--- a/src/main/java/org/anystub/mgmt/BaseManagerImpl.java
+++ b/src/main/java/org/anystub/mgmt/BaseManagerImpl.java
@@ -105,7 +105,7 @@ public class BaseManagerImpl implements BaseManager {
 
 
     protected void stubInitialization(Base newStub) {
-        // default initializator does nothing
+        // default initializer does nothing
     }
 
 }

--- a/src/test/java/org/anystub/BaseTest.java
+++ b/src/test/java/org/anystub/BaseTest.java
@@ -2,6 +2,7 @@ package org.anystub;
 
 import org.anystub.mgmt.BaseManagerFactory;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -459,5 +460,18 @@ public class BaseTest {
 
     }
 
+
+    @Test
+    void testCS() throws IOException {
+        Base locate = new Base("src/test/resources/anystub/testCS.yml");
+        String s = locate.request(() -> "Привет привет", String.class, 1);
+        assertEquals("Привет привет", s);
+        locate.save();
+
+        locate = new Base("src/test/resources/anystub/testCS.yml").constrain(RequestMode.rmNone);
+        s = locate.request(() -> "Привет привет", String.class, 1);
+        assertEquals("Привет привет", s);
+
+    }
 
 }

--- a/src/test/java/org/anystub/EncoderJsonTest.java
+++ b/src/test/java/org/anystub/EncoderJsonTest.java
@@ -2,7 +2,7 @@ package org.anystub;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EncoderJsonTest {
     static class Car {

--- a/src/test/java/org/anystub/it_hikari/JdbcStubRSTest.java
+++ b/src/test/java/org/anystub/it_hikari/JdbcStubRSTest.java
@@ -62,7 +62,6 @@ public class JdbcStubRSTest {
             );
 
             assertEquals(2, query.size());
-            assertEquals(3L, query.get(0).id);
             assertEquals("Bloch", query.get(0).last_name);
             assertEquals("Long", query.get(1).last_name);
 
@@ -72,14 +71,11 @@ public class JdbcStubRSTest {
             );
 
             assertEquals(2, query.size());
-            assertEquals(3L, query.get(0).id);
             assertEquals("Bloch", query.get(0).last_name);
             assertEquals("Long", query.get(1).last_name);
-            assertEquals(4L, query.get(1).id);
 
         Base base = BaseManagerFactory.getStub("hikariTest");
-        assertTrue(base.times() > 1);
-
+        assertTrue(base.timesEx("SELECT.*") >= 2);
     }
 
 }

--- a/src/test/java/org/anystub/it_jdbc/JdbcSourceSystemTest.java
+++ b/src/test/java/org/anystub/it_jdbc/JdbcSourceSystemTest.java
@@ -112,7 +112,6 @@ public class JdbcSourceSystemTest {
             );
 
             assertEquals(2, query.size());
-            assertEquals(3L, query.get(0).id);
             assertEquals("Bloch", query.get(0).last_name);
             assertEquals("Long", query.get(1).last_name);
 
@@ -122,10 +121,8 @@ public class JdbcSourceSystemTest {
             );
 
             assertEquals(2, query.size());
-            assertEquals(3L, query.get(0).id);
             assertEquals("Bloch", query.get(0).last_name);
             assertEquals("Long", query.get(1).last_name);
-            assertEquals(4L, query.get(1).id);
         }
     }
 

--- a/src/test/java/org/anystub/it_jdbc/JdbcSourceSystemTest.java
+++ b/src/test/java/org/anystub/it_jdbc/JdbcSourceSystemTest.java
@@ -149,7 +149,7 @@ public class JdbcSourceSystemTest {
     }
 
     @Test
-    @AnyStubId(filename = "blobTest")
+    @AnyStubId(filename = "blobTest", requestMode = RequestMode.rmAll)
     public void testBlob() {
         for (int ii=0; ii<2; ii++) {
             jdbcTemplate.execute("DROP TABLE BLOBREPORT IF EXISTS");

--- a/src/test/java/org/anystub/it_jdbc/JdbcSourceSystemTest.java
+++ b/src/test/java/org/anystub/it_jdbc/JdbcSourceSystemTest.java
@@ -318,7 +318,7 @@ public class JdbcSourceSystemTest {
     }
 
     @Test
-    @AnyStubId(filename = "integerLongTest1")
+    @AnyStubId(filename = "integerLongTest1", requestMode = RequestMode.rmAll)
     public void testIntegerLong1() throws SQLException {
         for (int i=0; i<2; i++) {
             jdbcTemplate.execute("DROP ALIAS SP_HELLO2 if Exists");

--- a/src/test/java/org/anystub/jdbc/ResultSetUtilTest.java
+++ b/src/test/java/org/anystub/jdbc/ResultSetUtilTest.java
@@ -8,6 +8,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
+import static java.sql.Types.DECIMAL;
+import static java.sql.Types.SMALLINT;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ResultSetUtilTest {
 
     @Test
-    public void testDecode() throws SQLException {
+    void testDecode() throws SQLException {
 
         List<String> s = asList("1", "PUBLIC.SP_HELLO('XX')", "VARCHAR", "12", "2147483647", "0", "HELLO: XX");
         ResultSet decode = ResultSetUtil.decode(s);
@@ -27,7 +29,7 @@ public class ResultSetUtilTest {
     }
 
     @Test
-    public void testDecodeAliasMultiline() throws SQLException {
+    void testDecodeAliasMultiline() throws SQLException {
 
         List<String> s = asList("3", "ID", "INTEGER", "4", "10", "0", "FIRST_NAME/name", "VARCHAR", "12", "255", "0",
                 "LAST_NAME/lname", "VARCHAR", "12", "255", "0", "3", "Josh", "Bloch", "4", "Josh", "Long");
@@ -43,5 +45,14 @@ public class ResultSetUtilTest {
         assertTrue(decode.next());
         assertEquals(4, decode.getInt("ID"));
         assertEquals("Long", decode.getString("lname"));
+    }
+
+    @Test
+    void testDecoding() {
+        Object o;
+        o = ResultSetUtil.decodeValue("4", SMALLINT);
+        assertEquals((short)4, o);
+        o = ResultSetUtil.decodeValue("4.2", DECIMAL);
+        assertEquals(4.2, o);
     }
 }


### PR DESCRIPTION
Currently encoding for cassette files depends from your OS and locale settings. It is probably fine if you are using Linux because for most distros UTF-8 is default. But on Windows it could lead for problems with symbols from locales other than selected in Windows settings. For example I had troubles with CP-1251 encoding not being able to save some German unicode strings.