### PR TITLE
fix NPE for columns which has NULL value

### DIFF
--- a/src/main/java/org/anystub/jdbc/ResultSetUtil.java
+++ b/src/main/java/org/anystub/jdbc/ResultSetUtil.java
@@ -158,6 +158,9 @@ public class ResultSetUtil {
 
     private static String encodeValue(ResultSet resultSet, int columnType, int column) {
         try {
+            if (resultSet.getObject(column) == null) {
+                return null;
+            }
             switch (columnType) {
 //            case  BIT = -7;
                 case TINYINT:

--- a/src/test/java/org/anystub/it_jdbc/JdbcSourceSystemTest.java
+++ b/src/test/java/org/anystub/it_jdbc/JdbcSourceSystemTest.java
@@ -289,6 +289,38 @@ public class JdbcSourceSystemTest {
     }
 
     @Test
+    @AnyStubId(requestMode = RequestMode.rmAll)
+    public void nullColumnValueTest() {
+        jdbcTemplate.execute("DROP TABLE NPETABLE IF EXISTS");
+
+        String sql = "CREATE TABLE NPETABLE(\n" +
+                "ID BIGINT PRIMARY KEY AUTO_INCREMENT,\n" +
+                "C_DATE DATE);";
+        jdbcTemplate.execute(sql);
+
+        String sqlI = "insert into NPETABLE (C_DATE) values (?)";
+        KeyHolder holder = new GeneratedKeyHolder();
+        int affectedRows = jdbcTemplate.update(new PreparedStatementCreator() {
+            @Override
+            public PreparedStatement createPreparedStatement(Connection connection) throws SQLException {
+                PreparedStatement preparedStatement = connection.prepareStatement(sqlI);
+                preparedStatement.setNull(1, Types.DATE);
+                return preparedStatement;
+            }
+        }, holder);
+
+        assertEquals(1, affectedRows);
+
+        List<String> query;
+
+        query = jdbcTemplate.query("select * from NPETABLE where id =?", new Object[]{1},
+                (resultSet, i) -> " " + resultSet.getDate("C_DATE"));
+
+        assertEquals(1, query.size());
+        assertEquals(" null", query.get(0));
+    }
+
+    @Test
     @AnyStubId(filename = "integerLongTest1")
     public void testIntegerLong1() throws SQLException {
         for (int i=0; i<2; i++) {


### PR DESCRIPTION
Currently there is no handling for cases where we have NULL stored in database for column. It leads to NPE in AnyStub. I suggest to add simple null check to avoid this problem.